### PR TITLE
Change 'Apps' to 'apps' to adhere to Python module naming standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Follow these steps to get your application running:
     ```sh
     cd apps
     ```
-4. **Clone the DjangoHexTemplate repository:**
+6. **Clone the DjangoHexTemplate repository:**
     ```
     git clone https://github.com/simuel/DjangoHexTemplate.git
     ```
-5. **Create a new app using the template:**
+7. **Create a new app using the template:**
     ```
     django-admin startapp --template=DjangoHexTemplate name_app
     ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Follow these steps to get your application running:
     ```sh
     cd name_proyect
     ```
+4. **Create a new directory**
+    ```sh
+    mkdir apps
+    ```
+5. **Navigate to the apps directory:**
+    ```sh
+    cd apps
+    ```
 4. **Clone the DjangoHexTemplate repository:**
     ```
     git clone https://github.com/simuel/DjangoHexTemplate.git

--- a/application/use_cases/manage_app_name.py
+++ b/application/use_cases/manage_app_name.py
@@ -1,4 +1,4 @@
-from Apps.{{app_name}}.domain.services.{{app_name}}_service import {{app_name.capitalize}}Service
+from apps.{{app_name}}.domain.services.{{app_name}}_service import {{app_name.capitalize}}Service
 
 class Manage{{app_name.capitalize}}:
     """

--- a/domain/entities/app_name.py
+++ b/domain/entities/app_name.py
@@ -1,5 +1,5 @@
 import uuid
-from Apps.{{app_name}}.domain.value_objects import *
+from apps.{{app_name}}.domain.value_objects import *
 
 class {{app_name.capitalize}}:
     def __init__(self, id=None):

--- a/domain/repositories/app_name_repository_django.py
+++ b/domain/repositories/app_name_repository_django.py
@@ -1,7 +1,7 @@
-from Apps.{{app_name}}.domain.entities.{{app_name}} import {{app_name.capitalize}}
-#from Apps.{{app_name}}.domain.value_objects import *
-from Apps.{{app_name}}.domain.repositories.interface_{{app_name}}_repository import I{{app_name.capitalize}}Repository
-from Apps.{{app_name}}.models import *  # Django ORM
+from apps.{{app_name}}.domain.entities.{{app_name}} import {{app_name.capitalize}}
+#from apps.{{app_name}}.domain.value_objects import *
+from apps.{{app_name}}.domain.repositories.interface_{{app_name}}_repository import I{{app_name.capitalize}}Repository
+from apps.{{app_name}}.models import *  # Django ORM
 
 class {{app_name.capitalize}}RepositoryDjango(I{{app_name.capitalize}}Repository):
 

--- a/domain/repositories/interface_app_name_repository.py
+++ b/domain/repositories/interface_app_name_repository.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from Apps.{{app_name}}.domain.entities.{{app_name}} import {{app_name.capitalize}}
+from apps.{{app_name}}.domain.entities.{{app_name}} import {{app_name.capitalize}}
 
 class I{{app_name.capitalize}}Repository(ABC):
     

--- a/domain/services/app_name_service.py
+++ b/domain/services/app_name_service.py
@@ -1,6 +1,6 @@
-from Apps.{{app_name}}.domain.repositories.interface_{{app_name}}_repository import I{{app_name.capitalize}}Repository
-from Apps.{{app_name}}.domain.entities.{{app_name}} import {{app_name.capitalize}}
-from Apps.{{app_name}}.domain.value_objects import *
+from apps.{{app_name}}.domain.repositories.interface_{{app_name}}_repository import I{{app_name.capitalize}}Repository
+from apps.{{app_name}}.domain.entities.{{app_name}} import {{app_name.capitalize}}
+from apps.{{app_name}}.domain.value_objects import *
 
 class {{app_name.capitalize}}Service:
 

--- a/infrastructure/repositories/app_name_repository_django.py
+++ b/infrastructure/repositories/app_name_repository_django.py
@@ -1,8 +1,8 @@
 
-from Apps.{{app_name}}.domain.entities.{{app_name}} import {{app_name.capitalize}}
-from Apps.{{app_name}}.domain.value_objects import *
-from Apps.{{app_name}}.domain.repositories.interface_{{app_name}}_repository import I{{app_name.capitalize}}Repository
-from Apps.{{app_name}}.models import {{app_name.capitalize}}Model  # Importando el modelo de Django
+from apps.{{app_name}}.domain.entities.{{app_name}} import {{app_name.capitalize}}
+from apps.{{app_name}}.domain.value_objects import *
+from apps.{{app_name}}.domain.repositories.interface_{{app_name}}_repository import I{{app_name.capitalize}}Repository
+from apps.{{app_name}}.models import {{app_name.capitalize}}Model  # Importando el modelo de Django
 
 
 class {{app_name.capitalize}}RepositoryDjango(I{{app_name.capitalize}}Repository):

--- a/infrastructure/serializers/app_name_serializer.py
+++ b/infrastructure/serializers/app_name_serializer.py
@@ -1,7 +1,7 @@
 
 from rest_framework import serializers
-from Apps.{{app_name}}.domain.value_objects import *
-from Apps.{{app_name}}.domain.entities.{{app_name}} import {{app_name.capitalize}}
+from apps.{{app_name}}.domain.value_objects import *
+from apps.{{app_name}}.domain.entities.{{app_name}} import {{app_name.capitalize}}
 
 class {{app_name.capitalize}}Serializer(serializers.Serializer):
     id = serializers.UUIDField(read_only=True)

--- a/presentation/views.py
+++ b/presentation/views.py
@@ -3,11 +3,11 @@
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework import status
-from Apps.{{app_name}}.infrastructure.serializers.{{app_name}}_serializer import {{app_name.capitalize}}Serializer
-from Apps.{{app_name}}.domain.services.{{app_name}}_service import {{app_name.capitalize}}Service
-from Apps.{{app_name}}.infrastructure.repositories.{{app_name}}_repository_django import {{app_name.capitalize}}RepositoryDjango
-from Apps.{{app_name}}.application.use_cases.manage_{{app_name}} import Manage{{app_name.capitalize}}
-from Apps.{{app_name}}.domain.entities.{{app_name}} import {{app_name.capitalize}}
+from apps.{{app_name}}.infrastructure.serializers.{{app_name}}_serializer import {{app_name.capitalize}}Serializer
+from apps.{{app_name}}.domain.services.{{app_name}}_service import {{app_name.capitalize}}Service
+from apps.{{app_name}}.infrastructure.repositories.{{app_name}}_repository_django import {{app_name.capitalize}}RepositoryDjango
+from apps.{{app_name}}.application.use_cases.manage_{{app_name}} import Manage{{app_name.capitalize}}
+from apps.{{app_name}}.domain.entities.{{app_name}} import {{app_name.capitalize}}
 
 class {{app_name.capitalize}}ViewSet(viewsets.ViewSet):
     """


### PR DESCRIPTION
Change 'Apps' to 'apps' to adhere to Python module naming standards
